### PR TITLE
final

### DIFF
--- a/src/plugins/db.ts
+++ b/src/plugins/db.ts
@@ -1,13 +1,19 @@
 import fp from 'fastify-plugin';
 import DB from '../utils/DB/DB';
+import { DataLoaders } from './loader';
+
 
 export default fp(async (fastify): Promise<void> => {
   const db = new DB();
+  const loaders = new DataLoaders(db);
+
   fastify.decorate('db', db);
+  fastify.decorate('loaders', loaders);
 });
 
 declare module 'fastify' {
   export interface FastifyInstance {
     db: DB;
+    loaders: DataLoaders
   }
 }

--- a/src/plugins/loader.ts
+++ b/src/plugins/loader.ts
@@ -1,0 +1,71 @@
+import * as DataLoader from 'dataloader';
+import DB from '../utils/DB/DB';
+import { MemberTypeEntity } from '../utils/DB/entities/DBMemberTypes';
+import { PostEntity } from '../utils/DB/entities/DBPosts';
+import { ProfileEntity } from '../utils/DB/entities/DBProfiles';
+import { UserEntity } from '../utils/DB/entities/DBUsers';
+import { ErrorMessages } from '../utils/response';
+
+export class DataLoaders {
+    users: DataLoader<any, UserEntity>;
+    posts: DataLoader<any, PostEntity>;
+    profiles: DataLoader<any, ProfileEntity>;
+    memberTypes: DataLoader<any, MemberTypeEntity>;
+  
+    constructor(db: DB) {
+      this.users = new DataLoader(async (keys) => {
+        const results = await db.users.findMany({
+            key: 'id',
+            equalsAnyOf: keys as string[]
+        });
+
+        return keys.map(key =>
+          results.find((item) => item.id == key)
+          || new Error(`${ErrorMessages.USER_ERROR} [${key}]`)
+        );
+      });
+
+      this.posts = new DataLoader(async (keys) => {
+        const results = await db.posts.findMany({
+            key: 'id',
+            equalsAnyOf: keys as any[]
+        });
+
+        return keys.map(key =>
+          results.find((item) => item.id == key)
+          || new Error(`${ErrorMessages.POST_ERROR} [${key}]`)
+        );
+      });
+
+      this.profiles = new DataLoader(async (keys) => {
+        const results = await db.profiles.findMany({
+            key: 'id',
+            equalsAnyOf: keys as any[]
+        });
+        
+        return keys.map(key =>
+          results.find((item) => item.id == key)
+          || new Error(`${ErrorMessages.PROFILE_ERROR} [${key}]`)
+        );
+      });
+
+      this.memberTypes = new DataLoader(async (keys) => {
+        const results = await db.memberTypes.findMany({
+            key: 'id',
+            equalsAnyOf: keys as any[]
+        });
+
+        return keys.map(key =>
+          results.find((item) => item.id == key)
+          || new Error(`${ErrorMessages.MEMBER_TYPE_ERROR} [${key}]`)
+        );
+      });
+    }
+  
+    public clearCache() {
+      this.users.clearAll();
+      this.posts.clearAll();
+      this.profiles.clearAll();
+      this.memberTypes.clearAll();
+    }
+  }

--- a/src/routes/graphql/index.ts
+++ b/src/routes/graphql/index.ts
@@ -1,18 +1,50 @@
 import { FastifyPluginAsyncJsonSchemaToTs } from '@fastify/type-provider-json-schema-to-ts';
+import { graphql, GraphQLSchema, parse, validate } from 'graphql';
+import { RootMutation } from './mutations';
+import { RootQuery } from './query';
 import { graphqlBodySchema } from './schema';
+import * as depthLimit from 'graphql-depth-limit';
+
+const GRAPHQL_DEPTH = 6;
 
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
-  fastify
+	fastify
 ): Promise<void> => {
-  fastify.post(
-    '/',
-    {
-      schema: {
-        body: graphqlBodySchema,
-      },
-    },
-    async function (request, reply) {}
-  );
+	fastify.post(
+		'/',
+		{
+			schema: {
+				body: graphqlBodySchema,
+			},
+		},
+		async function (request, reply) {
+			const { query, variables } = request.body;
+
+			const schema: GraphQLSchema = new GraphQLSchema({
+				query: RootQuery,
+				mutation: RootMutation,
+			});
+
+			const errors = validate(schema, parse(String(query)), [
+				depthLimit(GRAPHQL_DEPTH),
+			]);
+
+			fastify.loaders.clearCache();
+
+			if (errors.length > 0) {
+				reply.send({ data: null, errors: errors });
+
+				return;
+			}
+
+			return await graphql({
+				schema: schema,
+				source: String(query),
+				variableValues: variables,
+				contextValue: fastify,
+			});
+		}
+	);
 };
 
 export default plugin;

--- a/src/routes/graphql/mutations/index.ts
+++ b/src/routes/graphql/mutations/index.ts
@@ -1,0 +1,309 @@
+import { FastifyInstance } from 'fastify';
+import { GraphQLNonNull, GraphQLObjectType } from 'graphql';
+import { MemberTypeEntity } from '../../../utils/DB/entities/DBMemberTypes';
+import { PostEntity } from '../../../utils/DB/entities/DBPosts';
+import { ProfileEntity } from '../../../utils/DB/entities/DBProfiles';
+import { UserEntity } from '../../../utils/DB/entities/DBUsers';
+import { ErrorMessages } from '../../../utils/response';
+import {
+	CreatePostDtoInput,
+	CreateProfileDtoInput,
+	CreateUserDtoInput,
+	GraphQLMemberType,
+	GraphQLPost,
+	GraphQLProfile,
+	GraphQLUser,
+	SubscribeUserDtoInput,
+	UnSubscribeUserDtoInput,
+	UpdateMemberDtoInput,
+	UpdatePostDtoInput,
+	UpdateProfileDtoInput,
+	UpdateUserDtoInput,
+} from '../types';
+
+export const RootMutation = new GraphQLObjectType({
+	name: 'RootMutationType',
+	fields: {
+		createUser: {
+			type: GraphQLUser,
+			args: { data: { type: new GraphQLNonNull(CreateUserDtoInput) } },
+			resolve: async (
+				_,
+				{ data }: Record<'data', Omit<UserEntity, 'id'>>,
+				context: FastifyInstance
+			) => {
+				return await context.db.users.create(data);
+			},
+		},
+		createPost: {
+			type: GraphQLPost,
+			args: { data: { type: new GraphQLNonNull(CreatePostDtoInput) } },
+			resolve: async (
+				_,
+				{ data }: Record<'data', Omit<PostEntity, 'id'>>,
+				context: FastifyInstance
+			) => {
+				const { userId } = data;
+
+				const user = await context.db.users.findOne({
+					key: 'id',
+					equals: userId,
+				});
+
+				if (!user) {
+					throw context.httpErrors.notFound(ErrorMessages.USER_ERROR);
+				}
+
+				const newPost = await context.db.posts.create(data);
+
+				return newPost;
+			},
+		},
+		createProfile: {
+			type: GraphQLProfile,
+			args: { data: { type: new GraphQLNonNull(CreateProfileDtoInput) } },
+			resolve: async (
+				_,
+				{ data }: Record<'data', Omit<ProfileEntity, 'id'>>,
+				context: FastifyInstance
+			) => {
+				const { userId, memberTypeId } = data;
+
+				const user = await context.db.users.findOne({
+					key: 'id',
+					equals: userId,
+				});
+
+				if (!user) {
+					throw context.httpErrors.notFound(ErrorMessages.USER_ERROR);
+				}
+
+				const profileByUserId = await context.db.profiles.findOne({
+					key: 'userId',
+					equals: userId,
+				});
+
+				if (profileByUserId !== null) {
+					throw context.httpErrors.badRequest(ErrorMessages.PROFILE_EXISTS);
+				}
+
+				const memberType = await context.db.memberTypes.findOne({
+					key: 'id',
+					equals: memberTypeId,
+				});
+
+				if (!memberType) {
+					throw context.httpErrors.notFound(ErrorMessages.MEMBER_TYPE_ERROR);
+				}
+
+				const newProfile = await context.db.profiles.create(data);
+
+				return newProfile;
+			},
+		},
+		updateUser: {
+			type: GraphQLUser,
+			args: { data: { type: new GraphQLNonNull(UpdateUserDtoInput) } },
+			resolve: async (
+				_,
+				{ data }: Record<'data', UserEntity>,
+				context: FastifyInstance
+			) => {
+				const { id } = data;
+
+				const user = await context.db.users.findOne({
+					key: 'id',
+					equals: id,
+				});
+
+				if (!user) {
+					throw context.httpErrors.notFound(ErrorMessages.USER_ERROR);
+				}
+
+				const updatedUser = await context.db.users.change(id, data);
+
+				return updatedUser;
+			},
+		},
+		updatePost: {
+			type: GraphQLPost,
+			args: { data: { type: new GraphQLNonNull(UpdatePostDtoInput) } },
+			resolve: async (
+				_,
+				{ data }: Record<'data', PostEntity>,
+				context: FastifyInstance
+			) => {
+				const { id } = data;
+
+				const post = await context.db.posts.findOne({
+					key: 'id',
+					equals: id,
+				});
+
+				if (!post) {
+					throw context.httpErrors.notFound(ErrorMessages.POST_ERROR);
+				}
+
+				const updatedPost = await context.db.posts.change(id, data);
+
+				return updatedPost;
+			},
+		},
+		updateProfile: {
+			type: GraphQLProfile,
+			args: { data: { type: new GraphQLNonNull(UpdateProfileDtoInput) } },
+			resolve: async (
+				_,
+				{ data }: Record<'data', ProfileEntity>,
+				context: FastifyInstance
+			) => {
+				const { id } = data;
+
+				const profile = await context.db.profiles.findOne({
+					key: 'id',
+					equals: id,
+				});
+
+				if (!profile) {
+					throw context.httpErrors.notFound(ErrorMessages.PROFILE_ERROR);
+				}
+
+				const updatedProfile = await context.db.profiles.change(id, data);
+
+				return updatedProfile;
+			},
+		},
+		updateMemberType: {
+			type: GraphQLMemberType,
+			args: { data: { type: new GraphQLNonNull(UpdateMemberDtoInput) } },
+			resolve: async (
+				_,
+				{ data }: Record<'data', MemberTypeEntity>,
+				context: FastifyInstance
+			) => {
+				const { id } = data;
+
+				const member = await context.db.memberTypes.findOne({
+					key: 'id',
+					equals: id,
+				});
+
+				if (!member) {
+					throw context.httpErrors.notFound(ErrorMessages.MEMBER_TYPE_ERROR);
+				}
+
+				const newMember = await context.db.memberTypes.change(id, data);
+
+				return newMember;
+			},
+		},
+		subscribeUser: {
+			type: GraphQLUser,
+			args: { data: { type: new GraphQLNonNull(SubscribeUserDtoInput) } },
+			resolve: async (
+				_,
+				{ data }: Record<'data', Pick<ProfileEntity, 'id' | 'userId'>>,
+				context: FastifyInstance
+			) => {
+				const { id, userId } = data;
+
+				if (id === userId) {
+					throw context.httpErrors.badRequest(ErrorMessages.USER_SUBSCRIBE);
+				}
+
+				const subscriber = await context.db.users.findOne({
+					key: 'id',
+					equals: id,
+				});
+
+				const candidate = await context.db.users.findOne({
+					key: 'id',
+					equals: userId,
+				});
+
+				if (!subscriber || !candidate) {
+					throw context.httpErrors.notFound(ErrorMessages.NOT_FOUND);
+				}
+
+				const followerIndex = subscriber.subscribedToUserIds.findIndex(
+					(follower: string) => follower === userId
+				);
+
+				if (followerIndex != -1) {
+					throw context.httpErrors.notFound(ErrorMessages.BAD_REQUEST);
+				}
+
+				const subscriberSubscribedToIds = [
+					...subscriber.subscribedToUserIds,
+					candidate.id,
+				];
+
+				const candidateSubscribedToUserIds = [
+					...candidate.subscribedToUserIds,
+					subscriber.id,
+				];
+
+				const updatedUser = await context.db.users.change(id, {
+					subscribedToUserIds: subscriberSubscribedToIds,
+				});
+
+				await context.db.users.change(userId, {
+					subscribedToUserIds: candidateSubscribedToUserIds,
+				});
+
+				return updatedUser;
+			},
+		},
+		unSubscribeUser: {
+			type: GraphQLUser,
+			args: { data: { type: new GraphQLNonNull(UnSubscribeUserDtoInput) } },
+			resolve: async (
+				_,
+				{ data }: Record<'data', Pick<ProfileEntity, 'id' | 'userId'>>,
+				context: FastifyInstance
+			) => {
+				const { id, userId } = data;
+
+				const unSubscriber = await context.db.users.findOne({
+					key: 'id',
+					equals: id,
+				});
+
+				const candidate = await context.db.users.findOne({
+					key: 'id',
+					equals: userId,
+				});
+
+				if (!unSubscriber || !candidate) {
+					throw context.httpErrors.notFound(ErrorMessages.NOT_FOUND);
+				}
+
+				const followerIndex = unSubscriber.subscribedToUserIds.findIndex(
+					(follower: string) => follower === userId
+				);
+
+				const subscriberIndex = candidate.subscribedToUserIds.findIndex(
+					(subscriber: string) => subscriber === id
+				);
+
+				if (followerIndex === -1 || subscriberIndex === -1) {
+					throw context.httpErrors.notFound(ErrorMessages.BAD_REQUEST);
+				}
+
+				const updatedUser = await context.db.users.change(id, {
+					subscribedToUserIds: unSubscriber.subscribedToUserIds.filter(
+						(follower: string) => follower != userId
+					),
+				});
+
+				await context.db.users.change(userId, {
+					subscribedToUserIds: candidate.subscribedToUserIds.filter(
+						(subscriber: string) => subscriber != id
+					),
+				});
+
+				return updatedUser;
+			},
+		},
+	},
+});

--- a/src/routes/graphql/query/index.ts
+++ b/src/routes/graphql/query/index.ts
@@ -1,0 +1,140 @@
+import { FastifyInstance } from 'fastify';
+import {
+	GraphQLList,
+	GraphQLNonNull,
+	GraphQLObjectType,
+	GraphQLString,
+} from 'graphql';
+import { MemberTypeEntity } from '../../../utils/DB/entities/DBMemberTypes';
+import { PostEntity } from '../../../utils/DB/entities/DBPosts';
+import { ProfileEntity } from '../../../utils/DB/entities/DBProfiles';
+import { UserEntity } from '../../../utils/DB/entities/DBUsers';
+import { ErrorMessages } from '../../../utils/response';
+import {
+	GraphQLMemberType,
+	GraphQLPost,
+	GraphQLProfile,
+	GraphQLUser,
+} from '../types';
+
+export const RootQuery = new GraphQLObjectType({
+	name: 'RootQueryType',
+	fields: {
+		users: {
+			type: new GraphQLList(GraphQLUser),
+			resolve: async (
+				source,
+				args,
+				context: FastifyInstance
+			): Promise<UserEntity[]> => {
+				return await context.db.users.findMany();
+			},
+		},
+		profiles: {
+			type: new GraphQLList(GraphQLProfile),
+			resolve: async (
+				source,
+				args,
+				context: FastifyInstance
+			): Promise<ProfileEntity[]> => {
+				return await context.db.profiles.findMany();
+			},
+		},
+		posts: {
+			type: new GraphQLList(GraphQLPost),
+			resolve: async (
+				source,
+				args,
+				context: FastifyInstance
+			): Promise<PostEntity[]> => {
+				return await context.db.posts.findMany();
+			},
+		},
+		memberTypes: {
+			type: new GraphQLList(GraphQLMemberType),
+			resolve: async (
+				source,
+				args,
+				context: FastifyInstance
+			): Promise<MemberTypeEntity[]> => {
+				return await context.db.memberTypes.findMany();
+			},
+		},
+		user: {
+			type: GraphQLUser,
+			args: {
+				id: { type: new GraphQLNonNull(GraphQLString) },
+			},
+			resolve: async (
+				_,
+				{ id },
+				context: FastifyInstance
+			): Promise<UserEntity> => {
+				const user = await context.loaders.users.load(id);
+
+				if (!user) {
+					throw context.httpErrors.notFound(ErrorMessages.USER_ERROR);
+				}
+
+				return user;
+			},
+		},
+		profile: {
+			type: GraphQLProfile,
+			args: {
+				id: { type: new GraphQLNonNull(GraphQLString) },
+			},
+			resolve: async (
+				_,
+				{ id },
+				context: FastifyInstance
+			): Promise<ProfileEntity> => {
+				const profile = await context.loaders.profiles.load(id);
+
+				if (!profile) {
+					throw context.httpErrors.notFound(ErrorMessages.PROFILE_ERROR);
+				}
+
+				return profile;
+			},
+		},
+		post: {
+			type: GraphQLPost,
+			args: {
+				id: { type: new GraphQLNonNull(GraphQLString) },
+			},
+			resolve: async (
+				_,
+				{ id },
+				context: FastifyInstance
+			): Promise<PostEntity> => {
+				const post = await context.loaders.posts.load(id);
+
+				if (!post) {
+					throw context.httpErrors.notFound(ErrorMessages.POST_ERROR);
+				}
+
+				return post;
+			},
+		},
+		memberType: {
+			type: GraphQLMemberType,
+			args: {
+				id: { type: new GraphQLNonNull(GraphQLString) },
+			},
+			resolve: async (
+				_,
+				{ id },
+				context: FastifyInstance
+			): Promise<MemberTypeEntity> => {
+				const memberType = await context.loaders.memberTypes.load(id);
+
+				if (!memberType) {
+					throw context.httpErrors.notFound(ErrorMessages.MEMBER_TYPE_ERROR);
+				}
+
+				return memberType;
+			},
+		},
+	},
+});

--- a/src/routes/graphql/schema.ts
+++ b/src/routes/graphql/schema.ts
@@ -1,34 +1,34 @@
 export const graphqlBodySchema = {
-  type: 'object',
-  properties: {
-    mutation: { type: 'string' },
-    query: { type: 'string' },
-    variables: {
-      type: 'object',
-    },
-  },
-  oneOf: [
-    {
-      type: 'object',
-      required: ['query'],
-      properties: {
-        query: { type: 'string' },
-        variables: {
-          type: 'object',
-        },
-      },
-      additionalProperties: false,
-    },
-    {
-      type: 'object',
-      required: ['mutation'],
-      properties: {
-        mutation: { type: 'string' },
-        variables: {
-          type: 'object',
-        },
-      },
-      additionalProperties: false,
-    },
-  ],
+	type: 'object',
+	properties: {
+		mutation: { type: 'string' },
+		query: { type: 'string' },
+		variables: {
+			type: 'object',
+		},
+	},
+	oneOf: [
+		{
+			type: 'object',
+			required: ['query'],
+			properties: {
+				query: { type: 'string' },
+				variables: {
+					type: 'object',
+				},
+			},
+			additionalProperties: false,
+		},
+		{
+			type: 'object',
+			required: ['mutation'],
+			properties: {
+				mutation: { type: 'string' },
+				variables: {
+					type: 'object',
+				},
+			},
+			additionalProperties: false,
+		},
+	],
 } as const;

--- a/src/routes/graphql/types/GraphQLMemberInput.ts
+++ b/src/routes/graphql/types/GraphQLMemberInput.ts
@@ -1,0 +1,15 @@
+import {
+	GraphQLID,
+	GraphQLInputObjectType,
+	GraphQLInt,
+	GraphQLNonNull,
+} from 'graphql';
+
+export const UpdateMemberDtoInput = new GraphQLInputObjectType({
+	name: 'UpdateMemberDtoInput',
+	fields: {
+		id: { type: new GraphQLNonNull(GraphQLID) },
+		discount: { type: GraphQLInt },
+		monthPostsLimit: { type: GraphQLInt },
+	},
+});

--- a/src/routes/graphql/types/GraphQLMemberType.ts
+++ b/src/routes/graphql/types/GraphQLMemberType.ts
@@ -1,0 +1,10 @@
+import { GraphQLInt, GraphQLObjectType, GraphQLString } from 'graphql';
+
+export const GraphQLMemberType = new GraphQLObjectType({
+	name: 'GraphQLMemberType',
+	fields: () => ({
+		id: { type: GraphQLString },
+		discount: { type: GraphQLInt },
+		monthPostsLimit: { type: GraphQLInt },
+	}),
+});

--- a/src/routes/graphql/types/GraphQLPost.ts
+++ b/src/routes/graphql/types/GraphQLPost.ts
@@ -1,0 +1,11 @@
+import { GraphQLID, GraphQLObjectType, GraphQLString } from 'graphql';
+
+export const GraphQLPost = new GraphQLObjectType({
+	name: 'GraphQLPost',
+	fields: () => ({
+		id: { type: GraphQLString },
+		title: { type: GraphQLString },
+		content: { type: GraphQLString },
+		userId: { type: GraphQLID },
+	}),
+});

--- a/src/routes/graphql/types/GraphQLPostInput.ts
+++ b/src/routes/graphql/types/GraphQLPostInput.ts
@@ -1,0 +1,24 @@
+import {
+	GraphQLID,
+	GraphQLInputObjectType,
+	GraphQLNonNull,
+	GraphQLString,
+} from 'graphql';
+
+export const CreatePostDtoInput = new GraphQLInputObjectType({
+	name: 'CreatePostDtoInput',
+	fields: {
+		content: { type: new GraphQLNonNull(GraphQLString) },
+		title: { type: new GraphQLNonNull(GraphQLString) },
+		userId: { type: new GraphQLNonNull(GraphQLID) },
+	},
+});
+
+export const UpdatePostDtoInput = new GraphQLInputObjectType({
+	name: 'UpdatePostDtoInput',
+	fields: {
+		id: { type: new GraphQLNonNull(GraphQLID) },
+		content: { type: GraphQLString },
+		title: { type: GraphQLString },
+	},
+});

--- a/src/routes/graphql/types/GraphQLProfile.ts
+++ b/src/routes/graphql/types/GraphQLProfile.ts
@@ -1,0 +1,21 @@
+import {
+	GraphQLID,
+	GraphQLInt,
+	GraphQLObjectType,
+	GraphQLString,
+} from 'graphql';
+
+export const GraphQLProfile = new GraphQLObjectType({
+	name: 'GraphQLProfile',
+	fields: () => ({
+		id: { type: GraphQLString },
+		userId: { type: GraphQLID },
+		avatar: { type: GraphQLString },
+		sex: { type: GraphQLString },
+		birthday: { type: GraphQLInt },
+		country: { type: GraphQLString },
+		street: { type: GraphQLString },
+		city: { type: GraphQLString },
+		memberTypeId: { type: GraphQLString },
+	}),
+});

--- a/src/routes/graphql/types/GraphQLProfileInput.ts
+++ b/src/routes/graphql/types/GraphQLProfileInput.ts
@@ -1,0 +1,35 @@
+import {
+	GraphQLID,
+	GraphQLInputObjectType,
+	GraphQLInt,
+	GraphQLNonNull,
+	GraphQLString,
+} from 'graphql';
+
+export const CreateProfileDtoInput = new GraphQLInputObjectType({
+	name: 'CreateProfileDtoInput',
+	fields: {
+		avatar: { type: new GraphQLNonNull(GraphQLString) },
+		sex: { type: new GraphQLNonNull(GraphQLString) },
+		birthday: { type: new GraphQLNonNull(GraphQLInt) },
+		country: { type: new GraphQLNonNull(GraphQLString) },
+		street: { type: new GraphQLNonNull(GraphQLString) },
+		city: { type: new GraphQLNonNull(GraphQLString) },
+		userId: { type: new GraphQLNonNull(GraphQLID) },
+		memberTypeId: { type: new GraphQLNonNull(GraphQLString) },
+	},
+});
+
+export const UpdateProfileDtoInput = new GraphQLInputObjectType({
+	name: 'UpdateProfileDtoInput',
+	fields: {
+		id: { type: new GraphQLNonNull(GraphQLID) },
+		avatar: { type: GraphQLString },
+		sex: { type: GraphQLString },
+		birthday: { type: GraphQLInt },
+		country: { type: GraphQLString },
+		street: { type: GraphQLString },
+		city: { type: GraphQLString },
+		memberTypeId: { type: GraphQLString },
+	},
+});

--- a/src/routes/graphql/types/GraphQLUser.ts
+++ b/src/routes/graphql/types/GraphQLUser.ts
@@ -1,0 +1,83 @@
+import { FastifyInstance } from 'fastify';
+import {
+	GraphQLID,
+	GraphQLList,
+	GraphQLObjectType,
+	GraphQLString,
+} from 'graphql';
+import { GraphQLMemberType } from './GraphQLMemberType';
+import { GraphQLPost } from './GraphQLPost';
+import { GraphQLProfile } from './GraphQLProfile';
+
+// @ts-ignore
+export const GraphQLUser = new GraphQLObjectType({
+	name: 'GraphQLUser',
+	fields: () => ({
+		id: { type: GraphQLID },
+		firstName: { type: GraphQLString },
+		lastName: { type: GraphQLString },
+		email: { type: GraphQLString },
+		subscribedToUserIds: {
+			type: new GraphQLList(GraphQLString),
+		},
+		subscribedToUser: {
+			type: new GraphQLList(GraphQLUser),
+			resolve: async (
+				{ subscribedToUserIds },
+				args,
+				context: FastifyInstance
+			) => {
+				return await context.db.users.findMany({
+					key: 'id',
+					equalsAnyOf: subscribedToUserIds,
+				});
+			},
+		},
+		userSubscribedTo: {
+			type: new GraphQLList(GraphQLUser),
+			resolve: async (
+				{ subscribedToUserIds },
+				args,
+				context: FastifyInstance
+			) => {
+				return await context.loaders.users.loadMany(subscribedToUserIds);
+			},
+		},
+		memberType: {
+			type: GraphQLMemberType,
+			resolve: async ({ id }, args, context: FastifyInstance) => {
+				const profile = await context.db.profiles.findOne({
+					key: 'userId',
+					equals: id,
+				});
+
+				if (!profile) {
+					return Promise.resolve(null);
+				}
+
+				return await context.db.memberTypes.findOne({
+					key: 'id',
+					equals: profile.memberTypeId,
+				});
+			},
+		},
+		posts: {
+			type: new GraphQLList(GraphQLPost),
+			resolve: async ({ id }, args, context: FastifyInstance) => {
+				return await context.db.posts.findMany({
+					key: 'userId',
+					equals: id,
+				});
+			},
+		},
+		profile: {
+			type: GraphQLProfile,
+			resolve: async ({ id }, args, context: FastifyInstance) => {
+				return await context.db.profiles.findOne({
+					key: 'userId',
+					equals: id,
+				});
+			},
+		},
+	}),
+});

--- a/src/routes/graphql/types/GraphQLUserInput.ts
+++ b/src/routes/graphql/types/GraphQLUserInput.ts
@@ -1,0 +1,41 @@
+import {
+	GraphQLID,
+	GraphQLInputObjectType,
+	GraphQLNonNull,
+	GraphQLString,
+} from 'graphql';
+
+export const CreateUserDtoInput = new GraphQLInputObjectType({
+	name: 'CreateUserDtoInput',
+	fields: {
+		firstName: { type: new GraphQLNonNull(GraphQLString) },
+		lastName: { type: new GraphQLNonNull(GraphQLString) },
+		email: { type: new GraphQLNonNull(GraphQLString) },
+	},
+});
+
+export const UpdateUserDtoInput = new GraphQLInputObjectType({
+	name: 'UpdateUserDtoInput',
+	fields: {
+		id: { type: new GraphQLNonNull(GraphQLID) },
+		firstName: { type: GraphQLString },
+		lastName: { type: GraphQLString },
+		email: { type: GraphQLString },
+	},
+});
+
+export const SubscribeUserDtoInput = new GraphQLInputObjectType({
+	name: 'SubscribeUserDtoInput',
+	fields: {
+		id: { type: new GraphQLNonNull(GraphQLID) },
+		userId: { type: new GraphQLNonNull(GraphQLID) },
+	},
+});
+
+export const UnSubscribeUserDtoInput = new GraphQLInputObjectType({
+	name: 'UnSubscribeUserDtoInput',
+	fields: {
+		id: { type: new GraphQLNonNull(GraphQLID) },
+		userId: { type: new GraphQLNonNull(GraphQLID) },
+	},
+});

--- a/src/routes/graphql/types/index.ts
+++ b/src/routes/graphql/types/index.ts
@@ -1,0 +1,16 @@
+export { GraphQLUser } from './GraphQLUser';
+export { GraphQLPost } from './GraphQLPost';
+export { GraphQLProfile } from './GraphQLProfile';
+export { GraphQLMemberType } from './GraphQLMemberType';
+export {
+	CreateUserDtoInput,
+	UpdateUserDtoInput,
+	SubscribeUserDtoInput,
+	UnSubscribeUserDtoInput,
+} from './GraphQLUserInput';
+export { CreatePostDtoInput, UpdatePostDtoInput } from './GraphQLPostInput';
+export {
+	CreateProfileDtoInput,
+	UpdateProfileDtoInput,
+} from './GraphQLProfileInput';
+export { UpdateMemberDtoInput } from './GraphQLMemberInput';

--- a/src/routes/member-types/index.ts
+++ b/src/routes/member-types/index.ts
@@ -8,7 +8,7 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
 ): Promise<void> => {
   fastify.get('/', async function (request, reply): Promise<
     MemberTypeEntity[]
-  > {});
+  > {return reply.send(fastify.db.memberTypes.findMany())});
 
   fastify.get(
     '/:id',
@@ -17,7 +17,20 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<MemberTypeEntity> {}
+    async function (request, reply): Promise<MemberTypeEntity> {
+      const member = await fastify.db.memberTypes.findOne({
+				key: 'id',
+				equals: request.params.id,
+			});
+
+			if (!member) {
+				return reply
+					.code(404)
+					.send({ message: "TYPE_ERROR" });
+			}
+
+			return reply.send(member);
+    }
   );
 
   fastify.patch(
@@ -28,7 +41,18 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<MemberTypeEntity> {}
+    async function (request, reply): Promise<MemberTypeEntity> {
+      try {
+				const newMember = await fastify.db.memberTypes.change(
+					request.params.id,
+					request.body
+				);
+
+				return reply.send(newMember);
+			} catch (error) {
+				return reply.code(400).send({ message: (error as Error).message });
+			}
+    }
   );
 };
 

--- a/src/routes/users/index.ts
+++ b/src/routes/users/index.ts
@@ -10,7 +10,9 @@ import type { UserEntity } from '../../utils/DB/entities/DBUsers';
 const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
   fastify
 ): Promise<void> => {
-  fastify.get('/', async function (request, reply): Promise<UserEntity[]> {});
+  fastify.get('/', async function (request, reply): Promise<UserEntity[]> {
+    return reply.send(fastify.db.users.findMany());
+  });
 
   fastify.get(
     '/:id',
@@ -19,7 +21,13 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+      const user = await fastify.db.users.findOne({
+				key: 'id',
+				equals: request.params.id,
+			});
+      return user ? reply.send(user) : reply.code(404).send({ message: 'Пользователь не найден' });
+    }
   );
 
   fastify.post(
@@ -29,7 +37,10 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         body: createUserBodySchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+      const createUser = await fastify.db.users.create(request.body)
+      return reply.status(201).send(createUser);
+    }
   );
 
   fastify.delete(
@@ -39,7 +50,38 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+      try {
+				const deletedUser = await fastify.db.users.delete(request.params.id);
+				const users = await fastify.db.users.findMany({
+					key: 'subscribedToUserIds',
+					equals: [deletedUser.id],
+				});
+				const posts = await fastify.db.posts.findMany({
+					key: 'userId',
+					equals: deletedUser.id,
+				});
+				const profile = await fastify.db.profiles.findOne({
+					key: 'userId',
+					equals: deletedUser.id,
+				});
+				if (profile) {
+					await fastify.db.profiles.delete(profile.id);
+				}
+				posts.forEach(async (post) => await fastify.db.posts.delete(post.id));
+				users.forEach(
+					async (user) =>
+						await fastify.db.users.change(user.id, {
+							subscribedToUserIds: user.subscribedToUserIds.filter(
+								(userId) => userId !== deletedUser.id
+							),
+						})
+				);
+				return reply.send(deletedUser);
+			} catch (error) {
+				return reply.status(400).send({ message: (error as Error).message });
+			}
+    }
   );
 
   fastify.post(
@@ -50,7 +92,42 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+      const subscriber = await fastify.db.users.findOne({
+				key: 'id',
+				equals: request.params.id,
+			});
+
+			const candidate = await fastify.db.users.findOne({
+				key: 'id',
+				equals: request.body.userId,
+			});
+
+			if (!subscriber || !candidate) {
+				return reply.status(404).send({ message: "Не найдено" });
+			}
+			const followerIndex = subscriber.subscribedToUserIds.findIndex(
+				(follower) => follower === request.body.userId
+			);
+			if (followerIndex != -1) {
+				return reply.status(400).send({ message: "Ошибка запроса" });
+			}
+			const subscriberSubscribedToIds = [
+				...subscriber.subscribedToUserIds,
+				candidate.id,
+			];
+			const candidateSubscribedToUserIds = [
+				...candidate.subscribedToUserIds,
+				subscriber.id,
+			];
+			const updatedUser = await fastify.db.users.change(request.params.id, {
+				subscribedToUserIds: subscriberSubscribedToIds,
+			});
+			await fastify.db.users.change(request.body.userId, {
+				subscribedToUserIds: candidateSubscribedToUserIds,
+			});
+			return reply.status(200).send(updatedUser);
+    }
   );
 
   fastify.post(
@@ -61,7 +138,39 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+      const us = await fastify.db.users.findOne({
+				key: 'id',
+				equals: request.params.id,
+			});
+			const theCandidate = await fastify.db.users.findOne({
+				key: 'id',
+				equals: request.body.userId,
+			});
+			if (!us || !theCandidate) {
+				return reply.status(404).send({ message: "Не найдено" });
+			}
+			const followerIndex = us.subscribedToUserIds.findIndex(
+				(follower) => follower === request.body.userId
+			);
+			const usIndex = theCandidate.subscribedToUserIds.findIndex(
+				(us) => us === request.params.id
+			);
+			if (followerIndex === -1 || usIndex === -1) {
+				return reply.status(400).send({ message: "Ошибка в запросе" });
+			}
+			const updatedUser = await fastify.db.users.change(request.params.id, {
+				subscribedToUserIds: us.subscribedToUserIds.filter(
+					(follower) => follower != request.body.userId
+				),
+			});
+			await fastify.db.users.change(request.body.userId, {
+				subscribedToUserIds: theCandidate.subscribedToUserIds.filter(
+					(subscriber) => subscriber != request.params.id
+				),
+			});
+			return reply.send(updatedUser);
+    }
   );
 
   fastify.patch(
@@ -72,7 +181,17 @@ const plugin: FastifyPluginAsyncJsonSchemaToTs = async (
         params: idParamSchema,
       },
     },
-    async function (request, reply): Promise<UserEntity> {}
+    async function (request, reply): Promise<UserEntity> {
+      try {
+				const updateUser = await fastify.db.users.change(
+					request.params.id,
+					request.body
+				);
+				return reply.send(updateUser);
+			} catch (error) {
+				return reply.status(400).send({ message: (error as Error).message });
+			}
+    }
   );
 };
 

--- a/src/test__schema/2.1
+++ b/src/test__schema/2.1
@@ -1,0 +1,30 @@
+query {
+    users {
+        id
+        firstName
+        lastName
+        email
+        subscribedToUserIds
+    }
+    posts {
+        id
+        userId
+        title
+        content
+    }
+    profiles {
+        id
+        userId
+        avatar
+        sex
+        birthday
+        country
+        street
+        city
+    }
+    memberTypes {
+        id
+        discount
+        monthPostsLimit
+    }
+}

--- a/src/test__schema/2.10
+++ b/src/test__schema/2.10
@@ -1,0 +1,10 @@
+mutation {
+    createPost(data: {
+        userId: "GUID"
+        title: "Amigo2",
+        content: "Doe",
+    })
+    {
+        id
+    }
+}

--- a/src/test__schema/2.12
+++ b/src/test__schema/2.12
@@ -1,0 +1,11 @@
+mutation {
+    updateUser(data: {
+        id: "GUID"
+        firstName: "Marry"
+        lastName: "Chilo"
+        email: "max-pane@example.com"
+    })
+    {
+        id
+    }
+}

--- a/src/test__schema/2.13
+++ b/src/test__schema/2.13
@@ -1,0 +1,15 @@
+mutation {
+    updateProfile(data: {
+        id: "GUID"
+        avatar: "new-image.png"
+        sex: "F"
+        birthday: 19
+        country: "RP"
+        street: "Kozlova"
+        city: "Minsk"
+        memberTypeId: "business"
+    })
+    {
+        id
+    }
+}

--- a/src/test__schema/2.14
+++ b/src/test__schema/2.14
@@ -1,0 +1,10 @@
+mutation {
+    updatePost(data: {
+        id: "GUID"
+        title: "Amigo2",
+        content: "Doe",
+    })
+    {
+        id
+    }
+}

--- a/src/test__schema/2.15
+++ b/src/test__schema/2.15
@@ -1,0 +1,9 @@
+mutation {
+    updateMemberType(data: {
+        profileId: "GUID"
+        memberTypeId: "business"
+    })
+    {
+        id
+    }
+}

--- a/src/test__schema/2.16
+++ b/src/test__schema/2.16
@@ -1,0 +1,9 @@
+mutation {
+    subscribeUser(data: {
+        id: "GUID"
+        userId: "GUID"
+    })
+    {
+        id
+    }
+}

--- a/src/test__schema/2.17
+++ b/src/test__schema/2.17
@@ -1,0 +1,9 @@
+mutation {
+    unSubscribeUser(data: {
+        id: "GUID"
+        userId: "GUID"
+    })
+    {
+        id
+    }
+}

--- a/src/test__schema/2.2
+++ b/src/test__schema/2.2
@@ -1,0 +1,23 @@
+query {
+    user (id: "GUID") {
+        firstName
+        lastName
+        email
+    }
+    post (id: "GUID") {
+        title
+        content
+    }
+    profile (id: "GUID") {
+        avatar
+        sex
+        birthday
+        country
+        street
+        city
+    }
+    memberType (id: "basic") {
+        discount
+        monthPostsLimit
+    }
+}

--- a/src/test__schema/2.3
+++ b/src/test__schema/2.3
@@ -1,0 +1,26 @@
+query {
+    users {
+        id
+        firstName
+        lastName
+        email
+        profile {
+            id
+            avatar
+            sex
+            birthday
+            country
+            street
+            city
+        }
+        posts {
+            id
+            title
+        }
+        memberType {
+            id
+            discount
+            monthPostsLimit
+        }
+    }
+}

--- a/src/test__schema/2.4
+++ b/src/test__schema/2.4
@@ -1,0 +1,23 @@
+query {
+    user (id: "GUID") {
+        firstName
+        lastName
+        email
+        profile {
+            avatar
+            sex
+            birthday
+            country
+            street
+            city
+        }
+        posts {
+            title
+        }
+        memberType {
+            id
+            discount
+            monthPostsLimit
+        }
+    }
+}

--- a/src/test__schema/2.5
+++ b/src/test__schema/2.5
@@ -1,0 +1,22 @@
+query {
+    users {
+        id
+        firstName
+        lastName
+        profile {
+            id
+            avatar
+            sex
+            birthday
+            country
+            street
+            city
+            memberTypeId
+        }
+        userSubscribedTo {
+            id
+            firstName
+            lastName
+        }
+    }
+}

--- a/src/test__schema/2.6
+++ b/src/test__schema/2.6
@@ -1,0 +1,16 @@
+query {
+    user (id: "GUID") {
+        firstName
+        lastName
+        email
+        posts {
+            id
+            title
+        }
+        subscribedToUser {
+            id
+            firstName
+            lastName
+        }
+    }
+}

--- a/src/test__schema/2.7
+++ b/src/test__schema/2.7
@@ -1,0 +1,37 @@
+query {
+    users {
+        id
+        firstName
+        lastName
+        userSubscribedTo {
+            id
+            firstName
+            lastName
+            userSubscribedTo {
+                id
+                firstName
+                lastName
+            }
+            subscribedToUser {
+                id
+                firstName
+                lastName
+            }
+        }
+        subscribedToUser {
+            id
+            firstName
+            lastName
+            userSubscribedTo {
+                id
+                firstName
+                lastName
+            }
+            subscribedToUser {
+                id
+                firstName
+                lastName
+            }
+        }
+    }
+}

--- a/src/test__schema/2.8
+++ b/src/test__schema/2.8
@@ -1,0 +1,10 @@
+mutation {
+    createUser(data: {
+        firstName: "Marry"
+        lastName: "Chilo"
+        email: "test@example.com"
+    })
+    {
+        id
+    }
+}

--- a/src/test__schema/2.9
+++ b/src/test__schema/2.9
@@ -1,0 +1,15 @@
+mutation {
+    createProfile(data: {
+        userId: "GUID"
+        avatar: "image.png"
+        sex: "M"
+        birthday: 23
+        country: "RB"
+        street: "Kozlova"
+        city: "Minsk"
+        memberTypeId: "basic"
+    })
+    {
+        id
+    }
+}

--- a/src/utils/response.ts
+++ b/src/utils/response.ts
@@ -1,0 +1,10 @@
+export enum ErrorMessages {
+	USER_ERROR = 'User not found',
+	USER_SUBSCRIBE = 'User try to subscribe on his self',
+	PROFILE_ERROR = 'Profile not found',
+	PROFILE_EXISTS = 'Profile already exists',
+	POST_ERROR = 'Post not found',
+	MEMBER_TYPE_ERROR = 'MemberType not found',
+	BAD_REQUEST = 'Bad Request',
+	NOT_FOUND = 'Not Found',
+};


### PR DESCRIPTION
Task: https://github.com/AlreadyBored/nodejs-assignments/blob/main/assignments/graphql-service/assignment.md
Solution: https://github.com/TimurDavlet/rsschool-nodejs-task-graphql
Done 2023-01-24  (deadline 2023-01-31 )
Score: 360 / 360

1. Add logic to the restful endpoints (users, posts, profiles, member-types folders in ./src/routes). - ok

2. Add logic to the graphql endpoint (graphql folder in ./src/routes).
Constraints and logic for gql queries should be done based on restful implementation.
For each subtask provide an example of POST body in the PR.
All dynamic values should be sent via "variables" field.
If the properties of the entity are not specified, then return the id of it.
userSubscribedTo - these are users that the current user is following.
subscribedToUser - these are users who are following the current user. -ok

3. Solve n+1 graphql problem with [dataloader](https://www.npmjs.com/package/dataloader) package in all places where it should be used.
You can use only one "findMany" call per loader to consider this task completed.
It's ok to leave the use of the dataloader even if only one entity was requested. But additionally (no extra score) you can optimize the behavior for such cases => +1 db call is allowed per loader. - ok

4. Limit the complexity of the graphql queries by their depth with [graphql-depth-limit](https://www.npmjs.com/package/graphql-depth-limit) package.
4.1. Provide a link to the line of code where it was used.
4.2. Specify a POST body of gql query that ends with an error due to the operation of the rule. Request result should be with errors field (and with or without data:null) describing the error. -ok 